### PR TITLE
Refactor make.jl and build docs in PR

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,8 +1,8 @@
 name: Documentation
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+  pull_request:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
@@ -30,4 +30,4 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          julia --project=docs docs/make.jl
+          julia --project=docs docs/make.jl ${{ github.ref == 'refs/heads/main' && '--deploy' || '' }}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+Comonicon = "863f3e99-da2a-4334-8734-de3dacbe5542"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 MultiDocumenter = "87ed4bf0-c935-4a67-83c3-2a03bee4197c"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,7 +19,7 @@ packages = [
     "Data" => [
         PkgInfo("InferenceObjects"),
         PkgInfo("ArviZExampleData"),
-        # PkgInfo("DimensionalData"; org="rafaqz", tag=external),
+        PkgInfo("DimensionalData"; org="rafaqz", tag=external),
         # PkgInfo("ArviZGen"; tag=experimental),
     ],
 ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,19 +1,45 @@
 using Downloads
 using MultiDocumenter
 
-function multi_doc_ref(pkg_name::String, org::String, tag=nothing)
-    name = pkg_name * (tag === nothing ? "" : " ($tag)")
+@enum Tag registered unregistered experimental external
+
+struct PkgInfo
+    name::String
+    org::String
+    tag::Tag
+end
+PkgInfo(name; org="arviz-devs", tag=registered) = PkgInfo(name, org, tag)
+
+packages = [
+    PkgInfo("ArviZ"),
+    "Plots" => [PkgInfo("ArviZPythonPlots"), PkgInfo("ArviZPlots"; tag=unregistered)],
+    "Stats" => [PkgInfo("PosteriorStats"), PkgInfo("PSIS")],
+    "Diagnostics" => [PkgInfo("MCMCDiagnosticTools"; org="TuringLang")],
+    "Data" => [
+        PkgInfo("InferenceObjects"),
+        PkgInfo("ArviZExampleData"),
+        # PkgInfo("DimensionalData"; org="rafaqz", tag=external),
+        # PkgInfo("ArviZGen"; tag=experimental),
+    ],
+]
+
+function dropdown(info::PkgInfo; clone_dir::String)
+    name = info.name * (info.tag == registered ? "" : " ($(info.tag))")
+    if info.tag == external
+        link = "https://$(info.org).github.io/$(info.name).jl/"
+        return MultiDocumenter.Link(name, link)
+    end
     return MultiDocumenter.MultiDocRef(;
-        upstream=joinpath(clone_dir, pkg_name),
-        path=pkg_name,
+        upstream=joinpath(clone_dir, info.name),
+        path=info.name,
         name=name,
-        giturl="https://github.com/$(org)/$(pkg_name).jl.git",
+        giturl="https://github.com/$(info.org)/$(info.name).jl.git",
+        fix_canonical_url=(info.tag == registered),
     )
 end
-function multi_doc_ref(section_name::String, packages::Vector)
-    return MultiDocumenter.DropdownNav(
-        section_name, map(Base.splat(multi_doc_ref), packages)
-    )
+function dropdown((section_name, packages)::Pair{String,Vector{PkgInfo}}; clone_dir::String)
+    refs = [dropdown(info; clone_dir) for info in packages]
+    return MultiDocumenter.DropdownNav(section_name, refs)
 end
 
 function deploy_to_ghpages(git_root, out_dir)
@@ -49,48 +75,44 @@ function deploy_to_ghpages(git_root, out_dir)
     return nothing
 end
 
-clone_dir = mktempdir(; cleanup=false)
-out_dir = mktempdir(; cleanup=false)
-
-packages = [
-    ("ArviZ", "arviz-devs"),
-    "Plots" => [
-        ("ArviZPythonPlots", "arviz-devs"),
-        ("ArviZPlots", "arviz-devs", "unregistered"),
-    ],
-    "Stats" => [("PosteriorStats", "arviz-devs"), ("PSIS", "arviz-devs")],
-    "Diagnostics" => [("MCMCDiagnosticTools", "TuringLang")],
-    "Data" => [
-        ("InferenceObjects", "arviz-devs"),
-        ("ArviZExampleData", "arviz-devs"),
-        # ("DimensionalData", "rafaqz", "third-party"),
-        # ("ArviZGen", "arviz-devs", "experimental"),
-    ],
-]
-
-MultiDocumenter.make(
-    out_dir,
-    map(Base.splat(multi_doc_ref), packages);
-    search_engine=MultiDocumenter.SearchConfig(;
-        index_versions=["stable"], engine=MultiDocumenter.FlexSearch
-    ),
-    brand_image=MultiDocumenter.BrandImage(".", joinpath("assets", "logo.png")),
-    custom_stylesheets=[joinpath("assets", "hide_turing_menu.css")],
-    custom_scripts=Any[joinpath("assets", "hide_turing_menu.js")],
+function make(;
+    clone_dir::String="", out_dir::String="", deploy::Bool=false
 )
+    if isempty(clone_dir)
+        clone_dir = mktempdir(; cleanup=false)
+    end
 
-# download logo
-assets_dir = joinpath(out_dir, "assets")
-mkpath(assets_dir)
-Downloads.download(
-    "https://raw.githubusercontent.com/arviz-devs/arviz-project/main/arviz_logos/ArviZ_fav.png",
-    joinpath(assets_dir, "logo.png");
-    verbose=true,
-)
-for fn in ["hide_turing_menu.js", "hide_turing_menu.css"]
-    cp(joinpath(@__DIR__, "assets", fn), joinpath(assets_dir, fn))
+    if isempty(out_dir)
+        out_dir = mktempdir(; cleanup=false)
+    end
+
+    MultiDocumenter.make(
+        out_dir,
+        [dropdown(pkgs_info; clone_dir) for pkgs_info in packages];
+        search_engine=MultiDocumenter.SearchConfig(;
+            index_versions=["stable"], engine=MultiDocumenter.FlexSearch
+        ),
+        brand_image=MultiDocumenter.BrandImage(".", joinpath("assets", "logo.png")),
+        custom_stylesheets=[joinpath("assets", "hide_turing_menu.css")],
+        custom_scripts=Any[joinpath("assets", "hide_turing_menu.js")],
+    )
+
+    # download logo
+    assets_dir = joinpath(out_dir, "assets")
+    mkpath(assets_dir)
+    Downloads.download(
+        "https://raw.githubusercontent.com/arviz-devs/arviz-project/main/arviz_logos/ArviZ_fav.png",
+        joinpath(assets_dir, "logo.png");
+        verbose=true,
+    )
+    for fn in ["hide_turing_menu.js", "hide_turing_menu.css"]
+        cp(joinpath(@__DIR__, "assets", fn), joinpath(assets_dir, fn))
+    end
+
+    # deploy to GitHub Pages
+    git_root = normpath(joinpath(@__DIR__, ".."))
+    deploy && deploy_to_ghpages(git_root, out_dir)
+    return nothing
 end
 
-# deploy to GitHub Pages
-git_root = normpath(joinpath(@__DIR__, ".."))
-deploy_to_ghpages(git_root, out_dir)
+make()

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,4 @@
+using Comonicon
 using Downloads
 using MultiDocumenter
 
@@ -75,7 +76,19 @@ function deploy_to_ghpages(git_root, out_dir)
     return nothing
 end
 
-function make(;
+"""
+Build ArviZ Julia ecosystem docs using MultiDocumenter
+
+# Options
+
+- `-c, --clone-dir <arg>`: the directory where subpackage docs will be cloned
+- `-o, --out-dir <arg>`: the directory where docs will be built
+
+# Flags
+
+- `--deploy`: deploy docs using GitHub Pages
+"""
+Comonicon.@main function make(;
     clone_dir::String="", out_dir::String="", deploy::Bool=false
 )
     if isempty(clone_dir)
@@ -114,5 +127,3 @@ function make(;
     deploy && deploy_to_ghpages(git_root, out_dir)
     return nothing
 end
-
-make()


### PR DESCRIPTION
This PR refactors `make.jl` to be more modular and to execute more customizably using Comonicon.jl. Since this makes deployment optional (and disabled by default), the GA workflow only deploys on the main branch and builds the docs without deployment in PRs. 